### PR TITLE
requests-cache v0.9.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "requests-cache" %}
-{% set version = "0.9.5" %}
-{% set hash_val = "bd67575f541f9c10f44f8b49d8d449fb55db8af2e27d93c56349f227b78e4b70" %}
+{% set version = "0.9.6" %}
+{% set hash_val = "b1672c99ccce9ee53b49504c9f6a6d6de5cf6a9956bda46cf7dda0a4a5fc1bb5" %}
 
 package:
   name: {{ name|lower }}
@@ -24,9 +24,9 @@ requirements:
   run:
     - python >=3.7
     - appdirs >=1.4.4
-    - attrs <22.0,>=21.2
-    # cattrs 22.1+ depends on exceptiongroup, which doesn't have a stable release on conda-forge
-    - cattrs <22.1,>=1.8.1
+    - attrs >=21.2
+    - cattrs >=1.8.1
+    - exceptiongroup
     - itsdangerous >=2.0
     - pyyaml >=5.4
     - requests >=2.22
@@ -36,9 +36,8 @@ requirements:
 test:
   requires:
     - pip
-  # Disabling check against PyPI dependencies until conda dependencies can be updated to match
-  # commands:
-  #   - pip check
+  commands:
+    - pip check
   imports:
     - requests_cache
     - requests_cache.backends


### PR DESCRIPTION
This is a draft of changes to add for a future 0.9.6 patch release. To fix the issues noted in #35 and https://github.com/requests-cache/requests-cache/issues/675, there are two options:
* Change Conda package: Add an extra channel to allow a dependency on `exceptiongroup` (example in this PR)
* Change PyPI package: Restrict `cattrs` to <22.1

Neither option is ideal, but I would prefer to avoid adding more restrictions to the PyPI package since it has many more downstream dependencies. I'll give this a few weeks to see if the upstream issues sort themselves out.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
